### PR TITLE
Load files in series, calculate correct texture bias in HQ mode

### DIFF
--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -51,6 +51,7 @@ const choosePixelFormat = (device: pc.WebglGraphicsDevice): number => {
 class Multiframe {
     device: pc.WebglGraphicsDevice;
     camera: pc.CameraComponent;
+    textureBias: number;
     shader: pc.Shader = null;
     pixelFormat: number;
     multiframeTexUniform: pc.ScopeId = null;
@@ -64,6 +65,7 @@ class Multiframe {
     constructor(device: pc.WebglGraphicsDevice, camera: pc.CameraComponent, numSamples: number) {
         this.device = device;
         this.camera = camera;
+        this.textureBias = -Math.round(Math.log2(numSamples));
 
         // generate jittered grid samples (poisson would be better)
         for (let x = 0; x < numSamples; ++x) {
@@ -98,8 +100,8 @@ class Multiframe {
             this.camera._camera._viewMatDirty = true;
             this.camera._camera._viewProjMatDirty = true;
 
-            this.textureBiasUniform.setValue(this.sampleId === 0 ? 0.0 : -5.0);
-            // this.textureBiasUniform.setValue(-5.0);
+            this.textureBiasUniform.setValue(this.sampleId === 0 ? 0.0 : this.textureBias);
+            // this.textureBiasUniform.setValue(this.textureBias);
         };
 
         // restore the camera's projection matrix jitter once rendering is


### PR DESCRIPTION
The order in which we load GLB files is important. When loading a GLB containing a model and an associated animation in a separate GLB file, we must first add the model to the scene and then the animation. The viewer was just loading all GLBs at once and adding them to the scene as soon as they were finished loading.

This PR loads GLBs in series instead, in the order they are requested. This means multiple url `?load=` parameters will be loaded in series and animations should now work when coming from the editor.

Also calculate the correct textureBias in HQ mode.

Aside: we should consider updating the viewer codebase to use promises instead of this nasty callback structure.