### PR TITLE
Fix the error box layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -170,6 +170,10 @@ input {
     -ms-user-select: none;
 }
 
+.pcui-infobox.pcui-error {
+    position: absolute;
+}
+
 #load-controls .pcui-container {
     position: absolute;
 }


### PR DESCRIPTION
Fixes an issue with the display of error messages in the model viewer.

Before:
![image](https://user-images.githubusercontent.com/1721533/160175103-ad15f2a1-8a10-4637-9186-62e5ff21ef15.png)

After:
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/1721533/160175028-aaf27b11-e852-4264-8296-83df1a63afc6.png">

Fixes #153 

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
