### PR TITLE
Fix the useObserverState function

### DIFF
--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -7,13 +7,19 @@ import { Morph, Option, HierarchyNode } from './types';
 
 const ObserverContext = React.createContext(null);
 const ObserverProvider = ObserverContext.Provider;
+const observerSetFunctions: { [key: string]: (value: string | number | object) => void } = {};
 
 const useObserverState = (observer: Observer, path: string, json?: boolean) => {
     const parseFunc = (observerValue: any) => {
         return json ? JSON.parse(observerValue) : observerValue;
     };
     const [value, setValue] = useState(parseFunc(observer.get(path)));
-    observer.on(`${path}:set`, value => setValue(parseFunc(value)));
+    if (!observerSetFunctions[path]) {
+        observerSetFunctions[path] = (value: string | number | object) => {
+            setValue(parseFunc(value));
+        };
+        observer.on(`${path}:set`, observerSetFunctions[path]);
+    }
     return value;
 };
 


### PR DESCRIPTION
The useObserverState function in the controls file was registering multiple observer set functions for the same action. This meant as the UI reloaded, an increasing amount of events would fire, slowing down interactions with the page.

Fixes #120 
I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
