### PR TITLE
Multiframe update

### DIFF
--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -124,6 +124,11 @@ class Multiframe {
         device.on('devicelost', handler);
     }
 
+    // configure sampling
+    // numSamples: square root of number of samples: 5 === 25 total samples
+    // jitter: enable sample jittering
+    // size: size of the filter, in pixels
+    // sigma: guassian sigma filter value or 0 to use box filtering instead
     setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
         this.textureBias = -Math.log2(numSamples);
         this.samples = this.generateSamples(numSamples, jitter, size, sigma);

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -47,6 +47,11 @@ const choosePixelFormat = (device: pc.WebglGraphicsDevice): number => {
             pc.PIXELFORMAT_R8_G8_B8_A8;
 };
 
+// calculate 1d gauss
+const gauss = (x: number, sigma: number): number => {
+    return (1.0 / (Math.sqrt(2.0 * Math.PI) * sigma)) * Math.exp(-(x * x) / (2.0 * sigma * sigma));
+};
+
 // generate multiframe, supersampled AA
 class Multiframe {
     device: pc.WebglGraphicsDevice;
@@ -60,22 +65,30 @@ class Multiframe {
     accumTexture: pc.Texture = null;
     accumRenderTarget: pc.RenderTarget = null;
     sampleId = 0;
-    samples: pc.Vec2[] = [];
+    samples: pc.Vec3[] = [];
 
     constructor(device: pc.WebglGraphicsDevice, camera: pc.CameraComponent, numSamples: number) {
         this.device = device;
         this.camera = camera;
         this.textureBias = -Math.log2(numSamples);
 
+        const gaussSigma = 2;
+        const kernelSize = Math.ceil(3 * gaussSigma) + 1;
+
         // generate jittered grid samples (poisson would be better)
         for (let x = 0; x < numSamples; ++x) {
             for (let y = 0; y < numSamples; ++y) {
-                this.samples.push(new pc.Vec2(
-                    (x + Math.random()) / numSamples * 2.0 - 1.0,
-                    (y + Math.random()) / numSamples * 2.0 - 1.0
-                ));
+                const sx = x / (numSamples - 1) - 0.5; // * 2.0 - 1.0;
+                const sy = y / (numSamples - 1) - 0.5; // * 2.0 - 1.0;
+                const weight = 1; // gauss(sx * kernelSize, gaussSigma) * gauss(sy * kernelSize, gaussSigma);
+                this.samples.push(new pc.Vec3(sx, sy, weight));
             }
         }
+
+        // normalize weights
+        let totalWeight = 0;
+        this.samples.forEach(v => totalWeight += v.z);
+        this.samples.forEach(v => v.z /= totalWeight);
 
         // closes sample first
         this.samples.sort((a, b) => {
@@ -90,18 +103,21 @@ class Multiframe {
         // just before rendering the scene we apply a subpixel jitter
         // to the camera's projection matrix.
         this.camera.onPreRender = () => {
-            const sample = this.samples[this.sampleId];
-
             store.set(pmat.data[12], pmat.data[13]);
-            pmat.data[8] += sample.x / device.width;
-            pmat.data[9] += sample.y / device.height;
 
-            // look away
-            this.camera._camera._viewMatDirty = true;
-            this.camera._camera._viewProjMatDirty = true;
+            if (this.accumTexture) {
+                const sample = this.samples[this.sampleId];
 
-            this.textureBiasUniform.setValue(this.sampleId === 0 ? 0.0 : this.textureBias);
-            // this.textureBiasUniform.setValue(this.textureBias);
+                pmat.data[8] += sample.x / this.accumTexture.width;
+                pmat.data[9] += sample.y / this.accumTexture.height;
+
+                // look away
+                this.camera._camera._viewMatDirty = true;
+                this.camera._camera._viewProjMatDirty = true;
+
+                this.textureBiasUniform.setValue(this.sampleId === 0 ? 0.0 : this.textureBias);
+                // this.textureBiasUniform.setValue(this.textureBias);
+            }
         };
 
         // restore the camera's projection matrix jitter once rendering is
@@ -145,9 +161,11 @@ class Multiframe {
     }
 
     create() {
+        const source = this.camera.renderTarget.colorBuffer;
+
         this.accumTexture = new pc.Texture(this.device, {
-            width: this.device.width,
-            height: this.device.height,
+            width: source.width,
+            height: source.height,
             format: this.pixelFormat,
             mipmaps: false
         });
@@ -168,8 +186,10 @@ class Multiframe {
     // writes results to the backbuffer.
     update() {
         const device = this.device;
+        const sampleCnt = this.samples.length;
+        const sourceTex = this.camera.renderTarget.colorBuffer;
 
-        if (this.accumTexture && (this.accumTexture.width !== device.width || this.accumTexture.height !== device.height)) {
+        if (this.accumTexture && (this.accumTexture.width !== sourceTex.width || this.accumTexture.height !== sourceTex.height)) {
             this.destroy();
         }
 
@@ -177,16 +197,13 @@ class Multiframe {
             this.create();
         }
 
-        const sampleCnt = this.samples.length;
-        const sourceTex = this.camera.renderTarget.colorBuffer;
-
         if (this.sampleId < sampleCnt) {
-            if (this.sampleId === 0) {
-                // store the grabpass in both accumulation and current
-                this.multiframeTexUniform.setValue(sourceTex);
-                this.powerUniform.setValue(gamma);
-                pc.drawQuadWithShader(device, this.accumRenderTarget, this.shader, null, null, true);
-            } else {
+            // if (this.sampleId === 0) {
+            //     // store the grabpass in both accumulation and current
+            //     this.multiframeTexUniform.setValue(sourceTex);
+            //     this.powerUniform.setValue(gamma);
+            //     pc.drawQuadWithShader(device, this.accumRenderTarget, this.shader, null, null, true);
+            // } else {
                 // blend grabpass with accumulation buffer
                 const blendSrc = device.blendSrc;
                 const blendDst = device.blendDst;
@@ -197,8 +214,8 @@ class Multiframe {
                 const gl = device.gl;
 
                 // look away
-                gl.blendFuncSeparate(gl.CONSTANT_ALPHA, gl.ONE_MINUS_CONSTANT_ALPHA, gl.ONE, gl.ZERO);
-                gl.blendColor(0, 0, 0, 1.0 / (this.sampleId + 1));
+                gl.blendFuncSeparate(gl.CONSTANT_ALPHA, this.sampleId === 0 ? gl.ZERO : gl.ONE, gl.ONE, gl.ZERO);
+                gl.blendColor(0, 0, 0, this.samples[this.sampleId].z);
 
                 this.multiframeTexUniform.setValue(sourceTex);
                 this.powerUniform.setValue(gamma);
@@ -206,7 +223,7 @@ class Multiframe {
 
                 // restore states
                 device.setBlendFunctionSeparate(blendSrc, blendDst, blendSrcAlpha, blendDstAlpha);
-            }
+            // }
         }
 
         // update backbuffer on the first and last frame only

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -129,13 +129,13 @@ class Multiframe {
     // jitter: enable sample jittering
     // size: size of the filter, in pixels
     // sigma: guassian sigma filter value or 0 to use box filtering instead
-    setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
+    setSamples(numSamples: number, jitter = false, size = 1, sigma = 0) {
         this.textureBias = -Math.log2(numSamples);
         this.samples = this.generateSamples(numSamples, jitter, size, sigma);
         this.sampleId = 0;
     }
 
-    generateSamples(numSamples: number, jitter=false, size=1, sigma=0): pc.Vec3[] {
+    generateSamples(numSamples: number, jitter = false, size = 1, sigma = 0): pc.Vec3[] {
         const samples: pc.Vec3[] = [];
         const kernelSize = Math.ceil(3 * sigma) + 1;
         const halfSize = size * 0.5;
@@ -160,8 +160,12 @@ class Multiframe {
 
         // normalize weights
         let totalWeight = 0;
-        samples.forEach(v => totalWeight += v.z);
-        samples.forEach(v => v.z /= totalWeight);
+        samples.forEach((v) => {
+            totalWeight += v.z;
+        });
+        samples.forEach((v) => {
+            v.z /= totalWeight;
+        });
 
         // closest sample first
         samples.sort((a, b) => {

--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -158,7 +158,7 @@ class Multiframe {
         samples.forEach(v => totalWeight += v.z);
         samples.forEach(v => v.z /= totalWeight);
 
-        // closes sample first
+        // closest sample first
         samples.sort((a, b) => {
             const aL = a.length();
             const bL = b.length();

--- a/src/read-depth.ts
+++ b/src/read-depth.ts
@@ -100,11 +100,11 @@ class ReadDepth {
         }
 
         const device = this.device;
-        const tx = (x + 0.5) / depthTexture.width;
-        const ty = 1.0 - (y + 0.5) / depthTexture.height;
+        const tx = x + 0.5 / depthTexture.width;
+        const ty = y + 0.5 / depthTexture.height;
 
         this.depthTexUniform.setValue(depthTexture);
-        this.texcoordRangeUniform.setValue([tx, ty, tx, ty]);
+        this.texcoordRangeUniform.setValue([x, y, x, y]);
         pc.drawQuadWithShader(this.device, this.renderTarget, this.shader);
 
         const gl = device.gl;

--- a/src/read-depth.ts
+++ b/src/read-depth.ts
@@ -104,7 +104,7 @@ class ReadDepth {
         const ty = y + 0.5 / depthTexture.height;
 
         this.depthTexUniform.setValue(depthTexture);
-        this.texcoordRangeUniform.setValue([x, y, x, y]);
+        this.texcoordRangeUniform.setValue([tx, ty, tx, ty]);
         pc.drawQuadWithShader(this.device, this.renderTarget, this.shader);
 
         const gl = device.gl;

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -608,15 +608,15 @@ class Viewer {
         }
 
         // in with the new
-        const w = canvasSize.width * 0.25;
-        const h = canvasSize.height * 0.25;
+        const w = canvasSize.width;
+        const h = canvasSize.height;
         const colorBuffer = createTexture(w, h, pc.PIXELFORMAT_R8_G8_B8_A8);
         const depthBuffer = createTexture(w, h, pc.PIXELFORMAT_DEPTH);
         const renderTarget = new pc.RenderTarget({
             colorBuffer: colorBuffer,
             depthBuffer: depthBuffer,
             flipY: false,
-            samples: 1 // device.maxSamples
+            samples: device.maxSamples
         });
         this.camera.camera.renderTarget = renderTarget;
     }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1436,6 +1436,7 @@ class Viewer {
         }
     }
 
+    // temp, from debugger execute 'viewer.setSamples(5, false, 2, 0)'
     setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
         this.multiframe.setSamples(numSamples, jitter, size, sigma);
         this.renderNextFrame();

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1435,6 +1435,11 @@ class Viewer {
             this.app.renderNextFrame = true;
         }
     }
+
+    setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
+        this.multiframe.setSamples(numSamples, jitter, size, sigma);
+        this.renderNextFrame();
+    }
 }
 
 export default Viewer;

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1437,7 +1437,7 @@ class Viewer {
     }
 
     // to change samples at runtime execute in the debugger 'viewer.setSamples(5, false, 2, 0)'
-    setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
+    setSamples(numSamples: number, jitter = false, size = 1, sigma = 0) {
         this.multiframe.setSamples(numSamples, jitter, size, sigma);
         this.renderNextFrame();
     }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -211,14 +211,13 @@ class Viewer {
         // double click handler
         canvas.addEventListener('dblclick', (event) => {
             const camera = this.camera.camera;
+            const x = event.offsetX / canvas.clientWidth;
+            const y = 1.0 - event.offsetY / canvas.clientHeight;
 
             // read depth
-            const depth = this.readDepth.read(camera.renderTarget.depthBuffer, event.offsetX, event.offsetY);
+            const depth = this.readDepth.read(camera.renderTarget.depthBuffer, x, y);
 
             if (depth < 1) {
-                const x = event.offsetX / canvas.clientWidth;
-                const y = 1.0 - event.offsetY / canvas.clientHeight;
-
                 const pos = new pc.Vec4(x, y, depth, 1.0).mulScalar(2.0).subScalar(1.0);            // clip space
                 camera.projectionMatrix.clone().invert().transformVec4(pos, pos);                   // homogeneous view space
                 pos.mulScalar(1.0 / pos.w);                                                         // perform perspective divide
@@ -609,15 +608,15 @@ class Viewer {
         }
 
         // in with the new
-        const w = canvasSize.width;
-        const h = canvasSize.height;
+        const w = canvasSize.width * 0.25;
+        const h = canvasSize.height * 0.25;
         const colorBuffer = createTexture(w, h, pc.PIXELFORMAT_R8_G8_B8_A8);
         const depthBuffer = createTexture(w, h, pc.PIXELFORMAT_DEPTH);
         const renderTarget = new pc.RenderTarget({
             colorBuffer: colorBuffer,
             depthBuffer: depthBuffer,
             flipY: false,
-            samples: device.maxSamples
+            samples: 1 // device.maxSamples
         });
         this.camera.camera.renderTarget = renderTarget;
     }
@@ -1413,7 +1412,7 @@ class Viewer {
             }
         }
 
-        // this.app.drawWireSphere(this.cursorWorld, 0.01);
+        this.app.drawWireSphere(this.cursorWorld, 0.01);
     }
 
     private onPostrender() {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1412,7 +1412,7 @@ class Viewer {
             }
         }
 
-        this.app.drawWireSphere(this.cursorWorld, 0.01);
+        // this.app.drawWireSphere(this.cursorWorld, 0.01);
     }
 
     private onPostrender() {
@@ -1436,7 +1436,7 @@ class Viewer {
         }
     }
 
-    // temp, from debugger execute 'viewer.setSamples(5, false, 2, 0)'
+    // to change samples at runtime execute in the debugger 'viewer.setSamples(5, false, 2, 0)'
     setSamples(numSamples: number, jitter=false, size=1, sigma=0) {
         this.multiframe.setSamples(numSamples, jitter, size, sigma);
         this.renderNextFrame();


### PR DESCRIPTION
Multiframe rendering and depth reading logic was based on backbuffer dimensions instead of render target dimensions.

This PR fixes that and also adds alternative sampling layouts. Different sampling schemes can now be tested in the developer window using, for example:
```
viewer.setSamples(5, false, 2, 0);
```