### PR TITLE
Resolve msaa manually

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -627,7 +627,8 @@ class Viewer {
             colorBuffer: colorBuffer,
             depthBuffer: depthBuffer,
             flipY: false,
-            samples: observer.get('render.multisample') ? device.maxSamples : 1
+            samples: observer.get('render.multisample') ? device.maxSamples : 1,
+            autoResolve: false
         });
         this.camera.camera.renderTarget = renderTarget;
     }
@@ -1433,6 +1434,7 @@ class Viewer {
     private onPostrender() {
         // perform mulitiframe update, returned flag indicates whether more frames
         // are needed.
+        this.camera.camera.renderTarget.resolve();
         this.multiframeBusy = this.multiframe.update();
     }
 


### PR DESCRIPTION
Enabling render target `autoResolve` flag  results in many unnecessary resolves being performed under multisampling.

Here we resolve the multisample render target manually once a frame instead. This is a temporary fix till we can address the issue correctly in the engine.