### PR TITLE
Flash fix

### DIFF
--- a/src/multiframe.ts
+++ b/src/multiframe.ts
@@ -244,15 +244,7 @@ class Multiframe {
             const blendSrcAlpha = device.blendSrcAlpha;
             const blendDstAlpha = device.blendDstAlpha;
 
-            // TODO: add constant blend support to the engine
-            const gl = device.gl;
-
-            // look away
-            if (this.sampleId === 0) {
-                device.setBlendFunction(pc.BLENDMODE_CONSTANT_ALPHA, pc.BLENDMODE_ZERO);
-            } else {
-                device.setBlendFunction(pc.BLENDMODE_CONSTANT_ALPHA, pc.BLENDMODE_ONE);
-            }
+            device.setBlendFunction(pc.BLENDMODE_CONSTANT_ALPHA, this.sampleId === 0 ? pc.BLENDMODE_ZERO : pc.BLENDMODE_ONE);
             device.setBlendColor(0, 0, 0, this.samples[this.sampleId].z);
 
             this.multiframeTexUniform.setValue(sourceTex);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1433,11 +1433,13 @@ class Viewer {
     }
 
     private onPostrender() {
-        // perform mulitiframe update, returned flag indicates whether more frames
-        // are needed.
+        // resolve the (possibly multisampled) render target
         if (this.camera.camera.renderTarget._samples > 1) {
             this.camera.camera.renderTarget.resolve();
         }
+
+        // perform mulitiframe update. returned flag indicates whether more frames
+        // are needed.
         this.multiframeBusy = this.multiframe.update();
     }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -83,7 +83,6 @@ class Viewer {
                 // and would only result in extra memory usage.
                 antialias: false,
                 depth: false,
-                stencil: false,
                 preserveDrawingBuffer: true
             }
         });

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -82,7 +82,9 @@ class Viewer {
                 // the following aren't needed since we're rendering to an offscreen render target
                 // and would only result in extra memory usage.
                 antialias: false,
-                depth: false
+                depth: false,
+                stencil: false,
+                preserveDrawingBuffer: true
             }
         });
         this.app = app;
@@ -1434,7 +1436,9 @@ class Viewer {
     private onPostrender() {
         // perform mulitiframe update, returned flag indicates whether more frames
         // are needed.
-        this.camera.camera.renderTarget.resolve();
+        if (this.camera.camera.renderTarget._samples > 1) {
+            this.camera.camera.renderTarget.resolve();
+        }
         this.multiframeBusy = this.multiframe.update();
     }
 


### PR DESCRIPTION
The render target was flashing when HQ mode was enabled and MSAA disabled. This was due to invoking `resolve` on plain (non-MSAA) target.

This PR only calls RT `resolve` when multisampling is enabled (this test should be done by the engine, so added a [comment](https://github.com/playcanvas/engine/issues/4219#issuecomment-1115873044)).