### PR TITLE
Disable multisample toggle when msaa not supported

### DIFF
--- a/src/controls.tsx
+++ b/src/controls.tsx
@@ -76,9 +76,11 @@ const Select = (props: { name: string, path:string, type: string, options: Array
 Select.defaultProps = { enabled: true };
 
 const RenderPanel = () => {
+    const observer: Observer = useContext(ObserverContext);
+    const multisampleSupported: boolean = useObserverState(observer, 'render.multisampleSupported', true);
     return (
         <Panel headerText="RENDER" collapsible>
-            <Toggle name='multisample' path='render.multisample' />
+            <Toggle name='multisample' path='render.multisample' enabled={multisampleSupported}/>
             <Toggle name='hq' path='render.hq' label='High Quality' />
             <Select name='pixelScale' path='render.pixelScale' label='Pixel Scale' type='number' options={[1, 2, 4, 8, 16].map(v => ({ v: v, t: Number(v).toString() }))} />
         </Panel>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ interface Skybox {
 // initialize the apps state
 const observer: Observer = new Observer({
     render: {
+        multisampleSupported: true,
         multisample: true,
         hq: true,
         pixelScale: 1

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -90,6 +90,11 @@ class Viewer {
         app.graphicsDevice.maxPixelRatio = window.devicePixelRatio;
         app.scene.gammaCorrection = pc.GAMMA_SRGB;
 
+        // @ts-ignore
+        const multisampleSupported = app.graphicsDevice.maxSamples > 1;
+        observer.set('render.multisampleSupported', multisampleSupported);
+        observer.set('render.multisample', multisampleSupported && observer.get('render.multisample'));
+
         // register vox support
         VoxParser.registerVoxParser(app);
 


### PR DESCRIPTION
Currently the `multisample` toggle option is available even if the device does not support multisampling. This is very confusing.