### PR TITLE
Update build process

### DIFF
--- a/copy-and-watch.js
+++ b/copy-and-watch.js
@@ -21,9 +21,9 @@ export default function copyAndWatch(config) {
                 } else {
                     let dest;
                     if (fs.lstatSync(target.src).isDirectory()) {
-                        dest = path.join(target.dest, path.basename(target.destFilename || target.src), path.relative(target.src, pathname));
+                        dest = path.join(target.dest || '', path.basename(target.destFilename || target.src), path.relative(target.src, pathname));
                     } else {
-                        dest = path.join(target.dest, path.basename(target.destFilename || target.src));
+                        dest = path.join(target.dest || '', path.basename(target.destFilename || target.src));
                     }
                     resolvedConfig.targets.push({
                         src: pathname,

--- a/copy-and-watch.js
+++ b/copy-and-watch.js
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+// custom plugin to copy files and watch them
+export default function copyAndWatch(config) {
+    const resolvedConfig = {
+        targets: []
+    };
+
+    // resolve source directories into files
+    config.targets.forEach((target) => {
+        const readRec = (pathname) => {
+            if (!fs.existsSync(pathname)) {
+                console.log(`skipping missing file ${target.src}`);
+            } else {
+                if (fs.lstatSync(pathname).isDirectory()) {
+                    const children = fs.readdirSync(pathname);
+                    children.forEach((childPath) => {
+                        readRec(path.join(pathname, childPath));
+                    });
+                } else {
+                    let dest;
+                    if (fs.lstatSync(target.src).isDirectory()) {
+                        dest = path.join(target.dest, path.basename(target.destFilename || target.src), path.relative(target.src, pathname));
+                    } else {
+                        dest = path.join(target.dest, path.basename(target.destFilename || target.src));
+                    }
+                    resolvedConfig.targets.push({
+                        src: pathname,
+                        dest: dest,
+                        transform: target.transform
+                    });
+                }
+            }
+        };
+        readRec(target.src);
+    });
+
+    return {
+        name: 'copy-and-watch',
+        async buildStart() {
+            resolvedConfig.targets.forEach((target) => {
+                this.addWatchFile(target.src);
+            });
+        },
+        async generateBundle() {
+            resolvedConfig.targets.forEach((target) => {
+                const contents = fs.readFileSync(target.src);
+                this.emitFile({
+                    type: 'asset',
+                    fileName: target.dest,
+                    source: target.transform ? target.transform(contents, target.src) : contents
+                })
+            });
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -75,11 +75,11 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "lint": "eslint --ignore-pattern 'src/lib' --ext .ts src",
-    "serve": "serve dist",
     "build": "rollup -c",
     "build:watch": "rollup -c -w",
     "develop": "concurrently --kill-others \"npm run build:watch\" \"npm run serve\"",
-    "develop:local": "cross-env ENGINE_PATH=../engine npm run develop"
+    "develop:local": "cross-env ENGINE_PATH=../engine npm run develop",
+    "lint": "eslint --ignore-pattern 'src/lib' --ext .ts src",
+    "serve": "serve dist"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,10 +63,10 @@ export default {
     plugins: [
         copyAndWatch({
             targets: [
-                { src: 'src/style.css', dest: '' },
-                { src: 'src/fonts.css', dest: '' },
-                { src: 'static/', dest: '' },
-                { src: 'src/index.mustache', dest: '', destFilename: 'index.html', transform: compileMustache }
+                { src: 'src/index.mustache', destFilename: 'index.html', transform: compileMustache },
+                { src: 'src/style.css' },
+                { src: 'src/fonts.css' },
+                { src: 'static/' }
             ]
         }),
         alias({ entries: aliasEntries }),


### PR DESCRIPTION
This PR updates the build process as follows:
- add copy-and-watch rollup plugin for static files
- use a transformer to build the handles template so it updates during watch