### PR TITLE
Morph targets fix

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,7 +98,7 @@ const observerData: ObserverData = {
         },
         loadTime: null
     },
-    morphTargets: null,
+    morphs: null,
     spinner: false,
     error: null,
     xrSupported: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export interface Morph {
+export interface MorphTarget {
     name: string,
-    targetIndex?: number,
+    targetIndex: number,
     weight?: number
 }
 
@@ -100,7 +100,10 @@ export interface ObserverData {
         },
         loadTime?: number
     },
-    morphTargets?: any,
+    morphs?: Record<string, {
+        name: string,
+        targets: Record<string, MorphTarget>
+    }>,
     spinner: boolean,
     error?: string,
     xrSupported: boolean,

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -23,8 +23,8 @@ class App extends React.Component<{ observer: Observer }> {
         this.state = this._retrieveState();
 
         props.observer.on('*:set', (path: string) => {
-            // ignore any observer updates to specific morph targets
-            if (path.includes('morphTargets.')) return;
+            // ignore any observer updates to specific morph targets that aren't their weight
+            if (path.includes('morphs.')) return;
             // update the state
             this.setState(this._retrieveState());
         });

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import VisibilitySensor from 'react-visibility-sensor';
 import { Panel, Container, TreeViewItem, TreeView } from '@playcanvas/pcui/react/unstyled';
-import { Morph, HierarchyNode, SetProperty, ObserverData } from '../../types';
+import { HierarchyNode, SetProperty, ObserverData } from '../../types';
 
-import { Vector, Detail, Select, MorphSlider } from '../components';
+import { Vector, Detail, Select } from '../components';
 import { addEventListenerOnClickOnly } from '../../helpers';
+import MorphTargetPanel from './morph-target-panel';
 
 const toggleCollapsed = () => {
     const leftPanel = document.getElementById('panel-left');
@@ -93,46 +93,6 @@ class HierarchyPanel extends React.Component <{ sceneData: ObserverData['scene']
     }
 }
 
-class MorphTargetPanel extends React.Component <{ morphTargetData: ObserverData['morphTargets'], progress: number, setProperty: SetProperty }> {
-    shouldComponentUpdate(nextProps: Readonly<{ morphTargetData: ObserverData['morphTargets']; progress: number; setProperty: SetProperty; }>): boolean {
-        return (
-            JSON.stringify(nextProps.morphTargetData) !== JSON.stringify(this.props.morphTargetData) || nextProps.progress !== this.props.progress
-        );
-    }
-
-    render() {
-        const morphTargets: Record<string, {name: string, morphs: Record<string, Morph>}> = this.props.morphTargetData;
-        return morphTargets ? (
-            <Panel headerText='MORPH TARGETS' class='scene-morph-panel' collapsible={false}>
-                {Object.keys(morphTargets).map((key) => {
-                    const panel = morphTargets[key];
-                    return (
-                        <Panel key={`${key}.${panel.name}`} headerText={panel.name} collapsible class='morph-target-panel'>
-                            {Object.keys(panel.morphs).map((morphKey) => {
-                                const morph: Morph = panel.morphs[morphKey];
-                                return <div key={`${morphKey}`}>
-                                    <VisibilitySensor offset={{ top: -750, bottom: -750 }}>
-                                        {({ isVisible }: any) => {
-                                            return <div>{
-                                                isVisible ?
-                                                    <MorphSlider name={`${morph.name}`} precision={2} min={0} max={1}
-                                                        value={morphTargets[key].morphs[morph.targetIndex].weight}
-                                                        setProperty={(value: number) => this.props.setProperty(`morphTargets.${key}.morphs.${morph.targetIndex}.weight`, value)}
-                                                    /> :
-                                                    <div style={{ width: 30, height: 30 }}></div>
-                                            }</div>;
-                                        }}
-                                    </VisibilitySensor>
-                                </div>;
-                            })}
-                        </Panel>
-                    );
-                })}
-            </Panel>
-        ) : null;
-    }
-}
-
 class LeftPanel extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
     isMobile: boolean;
     constructor(props: any) {
@@ -165,13 +125,13 @@ class LeftPanel extends React.Component <{ observerData: ObserverData, setProper
 
     render() {
         const scene = this.props.observerData.scene;
-        const morphTargets = this.props.observerData.morphTargets;
+        const morphs = this.props.observerData.morphs;
         return (
             <Container id='scene-container' flex>
                 <ScenePanel sceneData={scene} setProperty={this.props.setProperty} />
                 <div id='scene-scrolly-bits'>
                     <HierarchyPanel sceneData={scene} setProperty={this.props.setProperty} />
-                    <MorphTargetPanel progress={this.props.observerData.animation.progress} morphTargetData={morphTargets} setProperty={this.props.setProperty} />
+                    <MorphTargetPanel progress={this.props.observerData.animation.progress} morphs={morphs} setProperty={this.props.setProperty} />
                 </div>
             </Container>
         );

--- a/src/ui/left-panel/morph-target-panel.tsx
+++ b/src/ui/left-panel/morph-target-panel.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import VisibilitySensor from 'react-visibility-sensor';
+import { MorphTarget, SetProperty, ObserverData } from '../../types';
+import { Panel } from '@playcanvas/pcui/react/unstyled';
+import { MorphSlider } from '../components';
+
+class MorphTargetPanel extends React.Component <{ morphs: ObserverData['morphs'], progress: number, setProperty: SetProperty }> {
+    shouldComponentUpdate(nextProps: Readonly<{ morphs: ObserverData['morphs']; progress: number; setProperty: SetProperty; }>): boolean {
+        return (
+            JSON.stringify(nextProps.morphs) !== JSON.stringify(this.props.morphs) || nextProps.progress !== this.props.progress
+        );
+    }
+
+    render() {
+        const morphs: any = this.props.morphs;
+        return morphs ? (
+            <Panel headerText='MORPH TARGETS' class='scene-morph-panel' collapsible={false}>
+                {Object.keys(morphs).map((morphIndex) => {
+                    const morph = morphs[morphIndex];
+                    return (
+                        <div key={`${morphIndex}.${morph.name}`}>
+                            <Panel headerText={morph.name} collapsible class='morph-target-panel'>
+                                {Object.keys(morph.targets).map((targetIndex: string) => {
+                                    const morphTarget: MorphTarget = morph.targets[targetIndex];
+                                    return <div key={targetIndex}>
+                                        <VisibilitySensor offset={{ top: -750, bottom: -750 }}>
+                                            {({ isVisible }: any) => {
+                                                return <div>{
+                                                    isVisible ?
+                                                        <MorphSlider name={`${morphTarget.name}`} precision={2} min={0} max={1}
+                                                            value={morphTarget.weight}
+                                                            setProperty={(value: number) => this.props.setProperty(`morphs.${morphIndex}.targets.${targetIndex}.weight`, value)}
+                                                        /> :
+                                                        <div style={{ width: 30, height: 30 }}></div>
+                                                }</div>;
+                                            }}
+                                        </VisibilitySensor>
+                                    </div>;
+                                })}
+                            </Panel>
+                        </div>
+                    );
+                })}
+            </Panel>
+        ) : null;
+    }
+}
+
+export default MorphTargetPanel;


### PR DESCRIPTION
Refactors the creation of morph target data in the viewer so it no longer depends on morph instances containing a reference to their mesh instance.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
