### PR TITLE
MorphTargetPanel animation update change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@playcanvas/eslint-config": "^1.2.0",
-        "@playcanvas/observer": "^1.3.1",
+        "@playcanvas/observer": "^1.3.2",
         "@playcanvas/pcui": "^2.8.0",
         "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^22.0.2",
@@ -307,9 +307,10 @@
       }
     },
     "node_modules/@playcanvas/observer": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.3.2.tgz",
+      "integrity": "sha512-zDI/dlOWp6m6ZopXvSP1chP83MYNXbKYpsAe/9AGfqWmzhnPbUzgB6YjL/pYX0g/VMO1VQP+5RuxcV9WtgIRpQ==",
+      "dev": true
     },
     "node_modules/@playcanvas/pcui": {
       "version": "2.8.0",
@@ -3861,7 +3862,9 @@
       }
     },
     "@playcanvas/observer": {
-      "version": "1.3.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.3.2.tgz",
+      "integrity": "sha512-zDI/dlOWp6m6ZopXvSP1chP83MYNXbKYpsAe/9AGfqWmzhnPbUzgB6YjL/pYX0g/VMO1VQP+5RuxcV9WtgIRpQ==",
       "dev": true
     },
     "@playcanvas/pcui": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@playcanvas/eslint-config": "^1.2.0",
-    "@playcanvas/observer": "^1.3.1",
+    "@playcanvas/observer": "^1.3.2",
     "@playcanvas/pcui": "^2.8.0",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^22.0.2",

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -22,9 +22,7 @@ class App extends React.Component<{ observer: Observer }> {
         this.canvasRef = React.createRef();
         this.state = this._retrieveState();
 
-        props.observer.on('*:set', (path: string) => {
-            // ignore any observer updates to specific morph targets that aren't their weight
-            if (path.includes('morphs.')) return;
+        props.observer.on('*:set', () => {
             // update the state
             this.setState(this._retrieveState());
         });

--- a/src/ui/left-panel/morph-target-panel.tsx
+++ b/src/ui/left-panel/morph-target-panel.tsx
@@ -7,7 +7,7 @@ import { MorphSlider } from '../components';
 class MorphTargetPanel extends React.Component <{ morphs: ObserverData['morphs'], progress: number, setProperty: SetProperty }> {
     shouldComponentUpdate(nextProps: Readonly<{ morphs: ObserverData['morphs']; progress: number; setProperty: SetProperty; }>): boolean {
         return (
-            JSON.stringify(nextProps.morphs) !== JSON.stringify(this.props.morphs) || nextProps.progress !== this.props.progress
+            JSON.stringify(nextProps.morphs) !== JSON.stringify(this.props.morphs)
         );
     }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1343,22 +1343,15 @@ class Viewer {
             }
         });
 
+        // @ts-ignore not exposed on Event class
+        this.observer.suspendEvents = true;
         this.observer.set('morphs', morphs);
+        // @ts-ignore not exposed on Event class
+        this.observer.suspendEvents = false;
 
         // handle animation update
         const observer = this.observer;
         observer.on('animationUpdate', () => {
-            Object.keys(morphs).forEach((morphIndex: string) => {
-                const morph = morphs[morphIndex];
-                Object.keys(morph.targets).forEach((targetIndex: string) => {
-                    const morphTarget: MorphTarget = morph.targets[targetIndex];
-                    const newWeight = morphInstances[morphIndex].getWeight(morphTarget.targetIndex);
-                    if (morphTarget.weight !== newWeight) {
-                        observer.set(`morphs.${morphIndex}.targets.${morphTarget.targetIndex}.weight`, newWeight);
-                    }
-                });
-            });
-
             // set progress
             for (let i = 0; i < this.entities.length; ++i) {
                 const entity = this.entities[i];

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1343,10 +1343,8 @@ class Viewer {
             }
         });
 
-        // @ts-ignore not exposed on Event class
         this.observer.suspendEvents = true;
         this.observer.set('morphs', morphs);
-        // @ts-ignore not exposed on Event class
         this.observer.suspendEvents = false;
 
         // handle animation update


### PR DESCRIPTION
To prioritise the performance of the application when animating assets with large amounts of morph targets, the MorphTargetPanel no longer subscribes to animation updates, however morph target sliders can still update the viewer application like before.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
