### PR TITLE
Add binary handler so loading gltf files work again

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ import {
     AnimClipHandler,
     AnimStateGraphHandler,
     // AudioHandler,
-    // BinaryHandler,
+    BinaryHandler,
     ContainerHandler,
     // CssHandler,
     CubemapHandler,
@@ -159,7 +159,8 @@ class App extends AppBase {
             // HierarchyHandler,
             // FolderHandler,
             // FontHandler,
-            // BinaryHandler,
+            // @ts-ignore
+            BinaryHandler,
             // TextureAtlasHandler,
             // SpriteHandler,
             // TemplateHandler,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,7 @@
         "allowSyntheticDefaultImports" : true,
         "esModuleInterop" : true,
         "sourceMap": true,
-        "moduleResolution": "node",
-        "baseUrl": ".",
-        "paths": {
-            "pcui": ["node_modules/@playcanvas/pcui/react"]
-        }
+        "moduleResolution": "node"
     },
     "include": ["src"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
Also remove the hard-coded tsconfig since rollup config handles this already (and supports local package override https://github.com/playcanvas/model-viewer/blob/main/rollup.config.mjs#L34).