### PR TITLE
Disable clustered lighting

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -141,6 +141,9 @@ class Viewer {
         });
         this.app = app;
 
+        // clustered not needed and has faster startup on windows
+        this.app.scene.clusteredLightingEnabled = false;
+
         // set xr supported
         observer.set('xrSupported', false);
         observer.set('xrActive', false);


### PR DESCRIPTION
Viewer doesn't need clustered lighting and startup is impacted on windows.