### PR TITLE
Fix camera popup UI test

### DIFF
--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -6,9 +6,48 @@ import QRious from 'qrious';
 
 import { Slider, Toggle, Select } from '../components';
 
+// extract members of the object given a list of paths to extract
+const extract = (obj: any, paths: string[]) => {
+
+    const resolve = (obj: any, path: string[]) => {
+        for (const p of path) {
+            if (!obj.hasOwnProperty(p)) {
+                return null;
+            }
+            obj = obj[p];
+        }
+        return obj;
+    };
+
+    const result: any = { };
+
+    for (const pathString of paths) {
+        const path = pathString.split('.');
+        const value = resolve(obj, path);
+
+        let parent = result;
+        for (let i = 0; i < path.length; ++i) {
+            const p = path[i];
+            if (i < path.length - 1) {
+                if (!parent.hasOwnProperty(p)) {
+                    parent[p] = { };
+                }
+                parent = parent[p];
+            } else {
+                parent[p] = value;
+            }
+        }
+    };
+
+    return result;
+};
+
 class CameraPanel extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
     shouldComponentUpdate(nextProps: Readonly<{ observerData: ObserverData; setProperty: SetProperty; }>): boolean {
-        return JSON.stringify(nextProps.observerData) !== JSON.stringify(this.props.observerData);
+        const keys = [ 'ui', 'show', 'render', 'lighting', 'animation.playing' ];
+        const a = extract(nextProps.observerData, keys);
+        const b = extract(this.props.observerData, keys);
+        return JSON.stringify(a) !== JSON.stringify(b);
     }
 
     render() {


### PR DESCRIPTION
Fixes: #202

The camera popup was not responsive when an animation was busy playing.

The component was rebuilding itself every frame, because animation time was included in the `shouldComponentUpdate` test.

This PR fixes that issue by extracting the part of the state that is needed.