### PR TITLE
iOS QuickLook AR Support

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ declare global {
     interface Window {
         pc: any;
         viewer: Viewer;
+        webkit?: any;
     }
 }
 

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -74,7 +74,7 @@ class PopupPanel extends React.Component <{ observerData: ObserverData, setPrope
     constructor(props: any) {
         super(props);
         this.link = (document.getElementById('ar-link') as HTMLAnchorElement);
-        if (this.link.relList.supports("ar")) {
+        if (this.link.relList.supports("ar") || (Boolean(window.webkit?.messageHandlers) && Boolean(/CriOS\/|EdgiOS\/|FxiOS\/|GSA\/|DuckDuckGo\//.test(navigator.userAgent)))) {
             // @ts-ignore
             this.usdzExporter = new UsdzExporter();
         }
@@ -87,7 +87,7 @@ class PopupPanel extends React.Component <{ observerData: ObserverData, setPrope
             <div id='floating-buttons-parent'>
                 <Button class='popup-button' icon='E189' hidden={!this.hasArSupport || this.props.observerData.scene.nodes === '[]'} width={40} height={40} onClick={() => {
                     if (this.usdzExporter) {
-                        const sceneRoot = (window as any).pc.app.root.findByName('sceneRoot');
+                        const sceneRoot = (window as any).viewer.app.root.findByName('sceneRoot');
                         // convert the loaded entity into asdz file
                         this.usdzExporter.build(sceneRoot).then((arrayBuffer: any) => {
                             const blob = new Blob([arrayBuffer], { type: 'application/octet-stream' });


### PR DESCRIPTION
This allows the viewer to actually convert scenes to USDZ on iOS. Not sure if it was a typo or a consequence of some engine update.

I've also added an additional check on WebKit browser, since QuickLook is supported on different iOS browsers as well. Same list is being used by Google's `model-viewer` (https://github.com/google/model-viewer/pull/3784/commits/71bb96c122ea92c624346b79ae64306de2ad0b92).

Worth nothing that I haven't checked this on MacOS to see if there's a false positive detection. Ideally, the check would include a strict iOS device check as well, but I'm in a rush right now. I'll revisit the PR if needed.