### PR TITLE
Allow loading .gltf from URL

### DIFF
--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -33,19 +33,14 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
     const onUrlSelected = () => {
         const viewer = (window as any).viewer;
         // @ts-ignore
-        const url = document.getElementById('glb-url-input').ui.value;
+        const url = new URL(document.getElementById('glb-url-input').ui.value);
         const loadList: Array<File> = [];
-        let filename = url.split('/').pop();
-        const extension = filename.endsWith('.gltf') ? '.gltf' : '.glb';
-        if (filename.indexOf(extension) === -1) {
-            if (filename.indexOf('?') === -1) {
-                filename += extension;
-            } else {
-                filename = filename.split('?')[0] + extension;
-            }
+        let filename = url.pathname.split('/').pop();
+        if (!filename.endsWith('.glb') && !filename.endsWith('.gltf')) {
+            filename += '.glb';
         }
         loadList.push({
-            url,
+            url: url.toString(),
             filename
         });
         viewer.loadFiles(loadList);

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -36,11 +36,12 @@ const LoadControls = (props: { setProperty: SetProperty }) => {
         const url = document.getElementById('glb-url-input').ui.value;
         const loadList: Array<File> = [];
         let filename = url.split('/').pop();
-        if (filename.indexOf('.glb') === -1) {
+        const extension = filename.endsWith('.gltf') ? '.gltf' : '.glb';
+        if (filename.indexOf(extension) === -1) {
             if (filename.indexOf('?') === -1) {
-                filename += '.glb';
+                filename += extension;
             } else {
-                filename = filename.split('?')[0] + '.glb';
+                filename = filename.split('?')[0] + extension;
             }
         }
         loadList.push({


### PR DESCRIPTION
Currently, pasting an URL in the `Load model from URL` box assumes the file extension is always `.glb`. This allows pasting `.gltf` extension as well, which already work fine by drag and dropping, or by using the `load`/`assetUrl` query string.