### PR TITLE
Meshopt loading fix

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -937,23 +937,23 @@ class Viewer {
             if (gltfBuffer.extensions && gltfBuffer.extensions.EXT_meshopt_compression) {
                 const extensionDef = gltfBuffer.extensions.EXT_meshopt_compression;
 
-                Promise.all([ MeshoptDecoder.ready, buffers[extensionDef.buffer] ])
-                .then((promiseResult) => {
-                    const buffer = promiseResult[1];
+                Promise.all([MeshoptDecoder.ready, buffers[extensionDef.buffer]])
+                    .then((promiseResult) => {
+                        const buffer = promiseResult[1];
 
-                    const byteOffset = extensionDef.byteOffset || 0;
-                    const byteLength = extensionDef.byteLength || 0;
+                        const byteOffset = extensionDef.byteOffset || 0;
+                        const byteLength = extensionDef.byteLength || 0;
 
-                    const count = extensionDef.count;
-                    const stride = extensionDef.byteStride;
+                        const count = extensionDef.count;
+                        const stride = extensionDef.byteStride;
 
-                    const result = new Uint8Array(count * stride);
-                    const source = new Uint8Array(buffer.buffer, buffer.byteOffset + byteOffset, byteLength);
+                        const result = new Uint8Array(count * stride);
+                        const source = new Uint8Array(buffer.buffer, buffer.byteOffset + byteOffset, byteLength);
 
-                    MeshoptDecoder.decodeGltfBuffer(result, count, stride, source, extensionDef.mode, extensionDef.filter);
+                        MeshoptDecoder.decodeGltfBuffer(result, count, stride, source, extensionDef.mode, extensionDef.filter);
 
-                    continuation(null, result);
-                });
+                        continuation(null, result);
+                    });
             } else {
                 continuation(null, null);
             }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -937,7 +937,10 @@ class Viewer {
             if (gltfBuffer.extensions && gltfBuffer.extensions.EXT_meshopt_compression) {
                 const extensionDef = gltfBuffer.extensions.EXT_meshopt_compression;
 
-                MeshoptDecoder.ready.then(() => {
+                Promise.all([ MeshoptDecoder.ready, buffers[extensionDef.buffer] ])
+                .then((promiseResult) => {
+                    const buffer = promiseResult[1];
+
                     const byteOffset = extensionDef.byteOffset || 0;
                     const byteLength = extensionDef.byteLength || 0;
 
@@ -945,9 +948,7 @@ class Viewer {
                     const stride = extensionDef.byteStride;
 
                     const result = new Uint8Array(count * stride);
-                    const source = new Uint8Array(buffers[extensionDef.buffer].buffer,
-                                                  buffers[extensionDef.buffer].byteOffset + byteOffset,
-                                                  byteLength);
+                    const source = new Uint8Array(buffer.buffer, buffer.byteOffset + byteOffset, byteLength);
 
                     MeshoptDecoder.decodeGltfBuffer(result, count, stride, source, extensionDef.mode, extensionDef.filter);
 


### PR DESCRIPTION
In a recent [engine PR](https://github.com/playcanvas/engine/pull/5291) we changed the gltf loading flow to be asynchronous in order to speed up load times.

As a result the gltf callbacks are now passing promises instead of concrete data.

This PR fixes model-viewer to handle the API change (which must be documented on the engine).