### PR TITLE
chore: general updates to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,18 @@ Some URL query parameters are available to override certain aspects of the viewe
 
 ## How to build
 
-Ensure you have [Node.js](https://nodejs.org) installed (v10.0+). Then, from a command prompt, run:
+Ensure you have [Node.js](https://nodejs.org) installed (v18.0+). Then, from a command prompt, run:
 
     npm install
     npm run build
 
-This will invoke Webpack and output the built viewer to the `dist` folder. To invoke Webpack with the `--watch` flag (which rebuilds the viewer on saving any source file), do:
+This will invoke Rollup and output the built viewer to the `dist` folder. To invoke Rollup with the `--watch` flag (which rebuilds the viewer on saving any source file), do:
 
-    npm run build:watch
-
-The size of the build can be checked by running:
-
-    npm run build:analyze
+    npm run watch
 
 ## How to build with local PlayCanvas engine
 
-You can set the npm build scripts to use local versions of the playcanvas engine & playcanvas extras builds by setting the following environment variables when launching the npm build scripts:
+You can set the npm build scripts to use local versions of the PlayCanvas engine & PlayCanvas extras builds by setting the following environment variables when launching the npm build scripts:
 
     ENGINE_PATH=./path/to/engine npm run build
 


### PR DESCRIPTION
This project uses Rollup to build.

- replace references to webpack with rolloup
- recommend node version to minimum supported by tools (18+)
- capitalise PlayCanvas

Fixes old references in readme.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
