### PR TITLE
chore: update to engine ^1.65.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint": "^8.48.0",
         "fflate": "^0.8.0",
         "handlebars": "^4.7.8",
-        "playcanvas": "1.64.4",
+        "playcanvas": "1.65.3",
         "prop-types": "^15.8.1",
         "qrious": "^4.0.2",
         "react": "^18.2.0",
@@ -3509,9 +3509,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "1.64.4",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.64.4.tgz",
-      "integrity": "sha512-Ser/rC8EPRvDU7VlXmI3hbFku3bR1RBluN/R+ElmzSHpYPxAZKM3PayqXI8miP2tTxp3KA8Woj/E6H1L9cohRQ==",
+      "version": "1.65.3",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-1.65.3.tgz",
+      "integrity": "sha512-ODxhVqYUe0mFcIFPcZhp0lmvSif/iLA2Y5/M3i0p0Ru1R1PZ+nLMyyxKqPGeCBqXh1Kqg5K4co0+Qk0y6BZd9Q==",
       "dev": true
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint": "^8.48.0",
     "fflate": "^0.8.0",
     "handlebars": "^4.7.8",
-    "playcanvas": "1.64.4",
+    "playcanvas": "^1.65.3",
     "prop-types": "^15.8.1",
     "qrious": "^4.0.2",
     "react": "^18.2.0",

--- a/src/shadow-catcher.ts
+++ b/src/shadow-catcher.ts
@@ -14,7 +14,7 @@ import {
 } from 'playcanvas';
 
 const endPS = `
-    litShaderArgs.opacity = mix(light0_shadowIntensity, 0.0, shadow0);
+    litArgs_opacity = mix(light0_shadowIntensity, 0.0, shadow0);
     gl_FragColor.rgb = vec3(0.0);
 `;
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -22,7 +22,7 @@ body {
 }
 
 #panel-left {
-    width: 300px;
+    width: 310px;
     height: 100%;
     background-color: #333333;
     display: flex;


### PR DESCRIPTION
Updates project to engine 1.65.3 and adjustments for PCUI 4.1.1

- updates dependency to "playcanvas": "^1.65.3",
- use new naming standard in shadow catcher shader fragment
- increase left panel default size so scroll bar does not show by default with the thicker fonts.

Fixes #229

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
