### PR TITLE
chore: update tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "inlineSources": true,
-        "noEmit": true
+        "noEmit": true,
+        "baseUrl": ".",
+        "paths": {
+            "pcui": ["node_modules/@playcanvas/pcui"],
+            "playcanvas-extras": ["node_modules/playcanvas/build/playcanvas-extras.mjs"]
+        }
     },
     "include": ["**/*.ts", "**/*.tsx"],
     "exclude": ["node_modules", "**/*.js", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,9 @@
         "sourceMap": true,
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "inlineSources": true
+        "inlineSources": true,
+        "noEmit": true
     },
     "include": ["**/*.ts", "**/*.tsx"],
-    "exclude": ["node_modules", "**/*.js"]
+    "exclude": ["node_modules", "**/*.js", "dist"]
 }


### PR DESCRIPTION
Update the tsconfig to remove warnings.

- correct tsconfig for type checking
- add default paths so tools can do autocomplete on aliases during development

The source uses import aliases so engine, extras, and pcui can be swapped out with local copies.  The Rollup build will swap these aliases for the correct value (package or local source).  Editors and other tools that offer autocomplete can not interpret these aliases unless they are set to some reasonable value in tsconfig.

Supports: #229

Fixes typescript autocomplete warnings for developers.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
