### PR TITLE
Add webgpu toggle

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,9 @@ const skyboxes = [
 
 const observerData: ObserverData = {
     ui: {
-        active: null
+        active: null,
+        spinner: false,
+        error: null
     },
     camera: {
         fov: 40,
@@ -146,13 +148,14 @@ const observerData: ObserverData = {
         loadTime: null
     },
     runtime: {
-        deviceType: ''
+        activeDeviceType: '',
+        viewportWidth: 0,
+        viewportHeight: 0,
+        xrSupported: false,
+        xrActive: false
     },
+    enableWebGPU: false,
     morphs: null,
-    spinner: false,
-    error: null,
-    xrSupported: false,
-    xrActive: false,
 };
 
 const saveOptions = (observer: Observer, name: string) => {
@@ -162,7 +165,8 @@ const saveOptions = (observer: Observer, name: string) => {
         skybox: options.skybox,
         light: options.light,
         debug: options.debug,
-        shadowCatcher: options.shadowCatcher
+        shadowCatcher: options.shadowCatcher,
+        enableWebGPU: options.enableWebGPU
     }));
 };
 
@@ -223,7 +227,7 @@ const main = () => {
     const skyboxUrls = new Map(skyboxes.map(s => [s.label, getAssetPath(s.url)]));
 
     // hide / show spinner when loading files
-    observer.on('spinner:set', (value: boolean) => {
+    observer.on('ui.spinner:set', (value: boolean) => {
         const spinner = document.getElementById('spinner');
         if (value) {
             spinner.classList.remove('pcui-hidden');
@@ -249,7 +253,7 @@ const main = () => {
 
     // create the graphics device
     createGraphicsDevice(canvas, {
-        deviceTypes: (url.searchParams.has('webgpu') ? ['webgpu'] : []).concat(['webgl2']),
+        deviceTypes: (url.searchParams.has('webgpu') || observer.get('enableWebGPU') ? ['webgpu'] : []).concat(['webgl2']),
         glslangUrl: getAssetPath('lib/glslang/glslang.js'),
         twgslUrl: getAssetPath('lib/twgsl/twgsl.js'),
         antialias: false,
@@ -258,7 +262,7 @@ const main = () => {
         xrCompatible: true,
         powerPreference: 'high-performance'
     }).then((device) => {
-        observer.set('runtime.deviceType', device.deviceType);
+        observer.set('runtime.activeDeviceType', device.deviceType);
 
         // create viewer instance
         const viewer = new Viewer(canvas, device, observer, skyboxUrls);

--- a/src/style.scss
+++ b/src/style.scss
@@ -274,6 +274,10 @@ input {
     overflow-y: auto;
 }
 
+#device-panel {
+    flex-shrink: 0;
+}
+
 .selected-node-panel-parent > .pcui-container {
     position: absolute;
 }
@@ -303,9 +307,8 @@ input {
     font-size: 14px;
 }
 
-.scene-hierarchy-panel > .pcui-panel-content,
-#scene-panel > .pcui-panel-content {
-    margin: 8px;
+.pcui-panel-content {
+    margin: 0px;
 }
 
 .selected-node-panel > .pcui-panel-content {
@@ -478,15 +481,21 @@ input {
 .panel-option {
     display: flex;
     align-items: center;
-    width: 100%;
+    width: calc(100% - 8px);
     height: 30px !important;
+    padding: 0px 0px 0px 8px;
+}
+
+#scene-panel > .pcui-panel-content > .panel-option:nth-child(even),
+#device-panel > .pcui-panel-content > .panel-option:nth-child(even) {
+    background-color: rgba(0, 0, 0, 0.1);
 }
 
 .panel-label {
-    width: 30%;
+    width: 40%;
     font-size: 14px;
     flex-shrink: 0;
-    margin: 2px;
+    margin: 0px;
 }
 
 .panel-label.pcui-disabled {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,9 @@ export interface HierarchyNode {
 
 export interface ObserverData {
     ui: {
-        active?: string
+        active?: string,
+        spinner: boolean,
+        error?: string,
     },
     camera: {
         fov: number,
@@ -134,12 +136,13 @@ export interface ObserverData {
         targets: Record<string, MorphTargetData>
     }>,
     runtime: {
-        deviceType: string
+        activeDeviceType: string,
+        viewportWidth: number,
+        viewportHeight: number,
+        xrSupported: boolean,
+        xrActive: boolean
     },
-    spinner: boolean,
-    error?: string,
-    xrSupported: boolean,
-    xrActive: boolean
+    enableWebGPU: boolean,
 }
 
 export type SetProperty = (path: string, value: any) => void;

--- a/src/ui/errors.tsx
+++ b/src/ui/errors.tsx
@@ -4,7 +4,7 @@ import { ObserverData } from '../types';
 
 // InfoBox that shows an error
 const ErrorBox = (props: { observerData: ObserverData }) => {
-    return <InfoBox class="pcui-error" title='Error' hidden={!props.observerData.error} text={props.observerData.error} icon='E218'/>;
+    return <InfoBox class="pcui-error" title='Error' hidden={!props.observerData.ui.error} text={props.observerData.ui.error} icon='E218'/>;
 };
 
 export default ErrorBox;

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Panel, Container, TreeViewItem, TreeView } from 'pcui';
 import { HierarchyNode, SetProperty, ObserverData } from '../../types';
 
-import { Vector, Detail, Select } from '../components';
+import { Detail, Select, Toggle, Vector } from '../components';
 import { addEventListenerOnClickOnly } from '../../helpers';
 import MorphTargetPanel from './morph-target-panel';
 
@@ -109,6 +109,32 @@ class HierarchyPanel extends React.Component <{ sceneData: ObserverData['scene']
     }
 }
 
+class DevicePanel extends React.Component <{
+    observerData: ObserverData,
+    setProperty: SetProperty}> {
+
+    shouldComponentUpdate(nextProps: Readonly<{ observerData: ObserverData; }>, nextState: Readonly<{}>, nextContext: any): boolean {
+        return JSON.stringify(nextProps.observerData.runtime) !== JSON.stringify(this.props.observerData.runtime) ||
+               nextProps.observerData.enableWebGPU !== this.props.observerData.enableWebGPU;
+    }
+
+    render() {
+        const runtime = this.props.observerData.runtime;
+        return (
+            <Panel headerText='DEVICE' id='device-panel' collapsible={false}>
+                <Toggle
+                    label="Use WebGPU"
+                    value={this.props.observerData.enableWebGPU}
+                    enabled={navigator.gpu !== undefined}
+                    setProperty={(value: boolean) => this.props.setProperty('enableWebGPU', value)}
+                />
+                <Detail label='Active Device' value={runtime.activeDeviceType === 'webgpu' ? 'webgpu (beta)' : runtime.activeDeviceType} />
+                <Detail label='Viewport' value={`${runtime.viewportWidth} x ${runtime.viewportHeight}`} />
+            </Panel>
+        );
+    }
+}
+
 class LeftPanel extends React.Component <{ observerData: ObserverData, setProperty: SetProperty }> {
     isMobile: boolean;
     constructor(props: any) {
@@ -149,6 +175,7 @@ class LeftPanel extends React.Component <{ observerData: ObserverData, setProper
                     <HierarchyPanel sceneData={scene} setProperty={this.props.setProperty} />
                     <MorphTargetPanel progress={this.props.observerData.animation.progress} morphs={morphs} setProperty={this.props.setProperty} />
                 </div>
+                <DevicePanel observerData={this.props.observerData} setProperty={this.props.setProperty} />
             </Container>
         );
     }

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -68,7 +68,7 @@ class PopupPanel extends React.Component <{ observerData: ObserverData, setPrope
     usdzExporter: any;
 
     get hasArSupport() {
-        return this.props.observerData.xrSupported || this.usdzExporter;
+        return this.props.observerData.runtime.xrSupported || this.usdzExporter;
     }
 
     constructor(props: any) {

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -58,7 +58,7 @@ class CameraPanel extends React.Component <{
                     <Toggle
                         label='High Quality'
                         value={props.observerData.camera.hq}
-                        enabled={!props.observerData.animation.playing && !props.observerData.debug.stats && props.observerData.runtime.deviceType !== 'webgpu' }
+                        enabled={!props.observerData.animation.playing && !props.observerData.debug.stats && props.observerData.runtime.activeDeviceType !== 'webgpu' }
                         setProperty={(value: boolean) => props.setProperty('camera.hq', value)}
                     />
                 </Container>
@@ -373,7 +373,7 @@ class ViewPanel extends React.Component <{
                     <Button
                         class='secondary'
                         text='TAKE A SNAPSHOT AS PNG'
-                        enabled={props.runtimeData.deviceType !== 'webgpu'}
+                        enabled={props.runtimeData.activeDeviceType !== 'webgpu'}
                         onClick={() => {
                             if (window.viewer) window.viewer.downloadPngScreenshot();
                         }}

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1056,8 +1056,8 @@ class Viewer {
 
             const loadTimestamp = Date.now();
 
-            this.observer.set('spinner', true);
-            this.observer.set('error', null);
+            this.observer.set('ui.spinner', true);
+            this.observer.set('ui.error', null);
             this.clearCta();
 
             // load asset files
@@ -1091,10 +1091,10 @@ class Viewer {
                     }
                 })
                 .catch((err) => {
-                    this.observer.set('error', err);
+                    this.observer.set('ui.error', err);
                 })
                 .finally(() => {
-                    this.observer.set('spinner', false);
+                    this.observer.set('ui.spinner', false);
                 });
         } else {
             // load skybox
@@ -1635,6 +1635,8 @@ class Viewer {
             const widthPixels = Math.floor(width * window.devicePixelRatio / pixelScale);
             const heightPixels = Math.floor(height * window.devicePixelRatio / pixelScale);
             this.app.graphicsDevice.setResolution(widthPixels, heightPixels);
+            this.observer.set('runtime.viewportWidth', widthPixels);
+            this.observer.set('runtime.viewportHeight', heightPixels);
             this.canvasResize = false;
         }
 


### PR DESCRIPTION
This PR adds an option to load webgpu at startup. It remains disabled till WebGPU morph targets work correctly.

We also show the active device and viewport pixel dimensions:

<img width="310" alt="Screenshot 2023-10-09 at 13 57 30" src="https://github.com/playcanvas/model-viewer/assets/11276292/ea92c8b8-e1ce-4896-b653-baa30657511a">

Also moved around observer options to further separate viewer config from runtime state.