### PR TITLE
Splat sorting fixes

### DIFF
--- a/src/splat/sort-manager.ts
+++ b/src/splat/sort-manager.ts
@@ -145,7 +145,7 @@ class SortManager {
 
             // send vertex storage to worker to start the next frame
             this.worker.postMessage({
-                data: oldData,
+                data: oldData
             }, [oldData]);
 
             this.vertexBuffer.setData(newData);
@@ -164,7 +164,6 @@ class SortManager {
             centers: centers.buffer,
             intIndices: intIndices
         }, [buf, centers.buffer]);
-
     }
 
     setCamera(pos: Vec3, dir: Vec3) {
@@ -173,6 +172,6 @@ class SortManager {
             cameraDirection: { x: dir.x, y: dir.y, z: dir.z }
         });
     }
-};
+}
 
 export { SortManager };

--- a/src/splat/sort-manager.ts
+++ b/src/splat/sort-manager.ts
@@ -1,3 +1,5 @@
+import { VertexBuffer } from "playcanvas";
+
 type Vec3 = {
     x: number,
     y: number,
@@ -12,7 +14,7 @@ function SortWorker() {
     let centers: Float32Array;
     let cameraPosition: Vec3;
     let cameraDirection: Vec3;
-    let isWebGPU: boolean;
+    let intIndices: boolean;
 
     const lastCameraPosition = { x: 0, y: 0, z: 0 };
     const lastCameraDirection = { x: 0, y: 0, z: 0 };
@@ -84,7 +86,7 @@ function SortWorker() {
         orderBuffer.sort();
 
         // order the splat data
-        if (isWebGPU) {
+        if (intIndices) {
             const target32 = new Uint32Array(target.buffer);
             for (let i = 0; i < numVertices; ++i) {
                 const index = orderBuffer32[i * 2];
@@ -117,8 +119,8 @@ function SortWorker() {
         if (message.data.centers) {
             centers = new Float32Array(message.data.centers);
         }
-        if (message.data.isWebGPU) {
-            isWebGPU = message.data.isWebGPU;
+        if (message.data.intIndices) {
+            intIndices = message.data.intIndices;
         }
         if (message.data.cameraPosition) cameraPosition = message.data.cameraPosition;
         if (message.data.cameraDirection) cameraDirection = message.data.cameraDirection;
@@ -127,4 +129,50 @@ function SortWorker() {
     };
 }
 
-export { SortWorker };
+class SortManager {
+    worker: Worker;
+    vertexBuffer: VertexBuffer;
+    updatedCallback: () => void;
+
+    constructor() {
+        this.worker = new Worker(URL.createObjectURL(new Blob([`(${SortWorker.toString()})()`], {
+            type: 'application/javascript'
+        })));
+
+        this.worker.onmessage = (message: any) => {
+            const newData = message.data.data;
+            const oldData = this.vertexBuffer.storage;
+
+            // send vertex storage to worker to start the next frame
+            this.worker.postMessage({
+                data: oldData,
+            }, [oldData]);
+
+            this.vertexBuffer.setData(newData);
+            this.updatedCallback?.();
+        };
+    }
+
+    sort(vertexBuffer: VertexBuffer, centers: Float32Array, intIndices: boolean, updatedCallback?: () => void) {
+        this.vertexBuffer = vertexBuffer;
+        this.updatedCallback = updatedCallback;
+
+        // send the initial buffer to worker
+        const buf = vertexBuffer.storage.slice(0);
+        this.worker.postMessage({
+            data: buf,
+            centers: centers.buffer,
+            intIndices: intIndices
+        }, [buf, centers.buffer]);
+
+    }
+
+    setCamera(pos: Vec3, dir: Vec3) {
+        this.worker.postMessage({
+            cameraPosition: { x: pos.x, y: pos.y, z: pos.z },
+            cameraDirection: { x: dir.x, y: dir.y, z: dir.z }
+        });
+    }
+};
+
+export { SortManager };

--- a/src/splat/splat-data.ts
+++ b/src/splat/splat-data.ts
@@ -3,12 +3,15 @@ import {
     BoundingBox,
     Color,
     Mat4,
-    Vec3
+    Vec3,
+    Quat
 } from "playcanvas";
 import { PlyElement } from "./ply-reader";
 
 const vec3 = new Vec3();
 const mat4 = new Mat4();
+const quat = new Quat();
+const quat2 = new Quat();
 const aabb = new BoundingBox();
 const aabb2 = new BoundingBox();
 
@@ -66,44 +69,66 @@ class SplatData {
         this.elements = elements;
         this.vertexElement = elements.find(element => element.name === 'vertex');
 
-        // mirror the scene in the x and y axis (both positions and rotations)
-        const x = this.getProp('x');
-        const y = this.getProp('y');
-        const rot_1 = this.getProp('rot_1');
-        const rot_2 = this.getProp('rot_2');
-
-        if (x && y && rot_1 && rot_2) {
-            for (let i = 0; i < this.numSplats; ++i) {
-                x[i] *= -1;
-                y[i] *= -1;
-                rot_1[i] *= -1;
-                rot_2[i] *= -1;
-            }
-        }
+        mat4.setScale(-1, -1, 1);
+        // mat4.setFromEulerAngles(-90, -90, 0);
+        this.transform(mat4);
     }
 
     get numSplats() {
         return this.vertexElement.count;
     }
 
-    getProp(name: string) {
+    // transform splat data by the given matrix
+    transform(mat: Mat4) {
+        const x = this.prop('x');
+        const y = this.prop('y');
+        const z = this.prop('z');
+
+        const rx = this.prop('rot_0');
+        const ry = this.prop('rot_1');
+        const rz = this.prop('rot_2');
+        const rw = this.prop('rot_3');
+
+        quat2.setFromMat4(mat);
+
+        for (let i = 0; i < this.numSplats; ++i) {
+            // transform center
+            vec3.set(x[i], y[i], z[i]);
+            mat.transformPoint(vec3, vec3);
+            x[i] = vec3.x;
+            y[i] = vec3.y;
+            z[i] = vec3.z;
+
+            // transform orientation
+            quat.set(ry[i], rz[i], rw[i], rx[i]).mul2(quat2, quat);
+            rx[i] = quat.w;
+            ry[i] = quat.x;
+            rz[i] = quat.y;
+            rw[i] = quat.z;
+
+            // TODO: transform SH
+        }
+    }
+
+    // access a named property
+    prop(name: string) {
         return this.vertexElement.properties.find((property: any) => property.name === name && property.storage)?.storage;
     }
 
     // calculate scene aabb taking into account splat size
     calcAabb(result: BoundingBox) {
-        const x = this.getProp('x');
-        const y = this.getProp('y');
-        const z = this.getProp('z');
+        const x = this.prop('x');
+        const y = this.prop('y');
+        const z = this.prop('z');
 
-        const rx = this.getProp('rot_0');
-        const ry = this.getProp('rot_1');
-        const rz = this.getProp('rot_2');
-        const rw = this.getProp('rot_3');
+        const rx = this.prop('rot_0');
+        const ry = this.prop('rot_1');
+        const rz = this.prop('rot_2');
+        const rw = this.prop('rot_3');
 
-        const sx = this.getProp('scale_0');
-        const sy = this.getProp('scale_1');
-        const sz = this.getProp('scale_2');
+        const sx = this.prop('scale_0');
+        const sy = this.prop('scale_1');
+        const sz = this.prop('scale_2');
 
         const splat = {
             x: 0, y: 0, z: 0, rx: 0, ry: 0, rz: 0, rw: 0, sx: 0, sy: 0, sz: 0
@@ -131,18 +156,18 @@ class SplatData {
     }
 
     renderWireframeBounds(app: AppBase, worldMat: Mat4) {
-        const x = this.getProp('x');
-        const y = this.getProp('y');
-        const z = this.getProp('z');
+        const x = this.prop('x');
+        const y = this.prop('y');
+        const z = this.prop('z');
 
-        const rx = this.getProp('rot_0');
-        const ry = this.getProp('rot_1');
-        const rz = this.getProp('rot_2');
-        const rw = this.getProp('rot_3');
+        const rx = this.prop('rot_0');
+        const ry = this.prop('rot_1');
+        const rz = this.prop('rot_2');
+        const rw = this.prop('rot_3');
 
-        const sx = this.getProp('scale_0');
-        const sy = this.getProp('scale_1');
-        const sz = this.getProp('scale_2');
+        const sx = this.prop('scale_0');
+        const sy = this.prop('scale_1');
+        const sz = this.prop('scale_2');
 
         const splat = {
             x: 0, y: 0, z: 0, rx: 0, ry: 0, rz: 0, rw: 0, sx: 0, sy: 0, sz: 0
@@ -177,13 +202,13 @@ class SplatData {
     }
 
     calcFocalPoint(result: Vec3) {
-        const x = this.getProp('x');
-        const y = this.getProp('y');
-        const z = this.getProp('z');
+        const x = this.prop('x');
+        const y = this.prop('y');
+        const z = this.prop('z');
 
-        const sx = this.getProp('scale_0');
-        const sy = this.getProp('scale_1');
-        const sz = this.getProp('scale_2');
+        const sx = this.prop('scale_0');
+        const sy = this.prop('scale_1');
+        const sz = this.prop('scale_2');
 
         let sum = 0;
         for (let i = 0; i < this.numSplats; ++i) {

--- a/src/splat/splat-data.ts
+++ b/src/splat/splat-data.ts
@@ -80,14 +80,14 @@ class SplatData {
 
     // transform splat data by the given matrix
     transform(mat: Mat4) {
-        const x = this.prop('x');
-        const y = this.prop('y');
-        const z = this.prop('z');
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
 
-        const rx = this.prop('rot_0');
-        const ry = this.prop('rot_1');
-        const rz = this.prop('rot_2');
-        const rw = this.prop('rot_3');
+        const rx = this.getProp('rot_0');
+        const ry = this.getProp('rot_1');
+        const rz = this.getProp('rot_2');
+        const rw = this.getProp('rot_3');
 
         quat2.setFromMat4(mat);
 
@@ -111,24 +111,24 @@ class SplatData {
     }
 
     // access a named property
-    prop(name: string) {
+    getProp(name: string) {
         return this.vertexElement.properties.find((property: any) => property.name === name && property.storage)?.storage;
     }
 
     // calculate scene aabb taking into account splat size
     calcAabb(result: BoundingBox) {
-        const x = this.prop('x');
-        const y = this.prop('y');
-        const z = this.prop('z');
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
 
-        const rx = this.prop('rot_0');
-        const ry = this.prop('rot_1');
-        const rz = this.prop('rot_2');
-        const rw = this.prop('rot_3');
+        const rx = this.getProp('rot_0');
+        const ry = this.getProp('rot_1');
+        const rz = this.getProp('rot_2');
+        const rw = this.getProp('rot_3');
 
-        const sx = this.prop('scale_0');
-        const sy = this.prop('scale_1');
-        const sz = this.prop('scale_2');
+        const sx = this.getProp('scale_0');
+        const sy = this.getProp('scale_1');
+        const sz = this.getProp('scale_2');
 
         const splat = {
             x: 0, y: 0, z: 0, rx: 0, ry: 0, rz: 0, rw: 0, sx: 0, sy: 0, sz: 0
@@ -156,18 +156,18 @@ class SplatData {
     }
 
     renderWireframeBounds(app: AppBase, worldMat: Mat4) {
-        const x = this.prop('x');
-        const y = this.prop('y');
-        const z = this.prop('z');
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
 
-        const rx = this.prop('rot_0');
-        const ry = this.prop('rot_1');
-        const rz = this.prop('rot_2');
-        const rw = this.prop('rot_3');
+        const rx = this.getProp('rot_0');
+        const ry = this.getProp('rot_1');
+        const rz = this.getProp('rot_2');
+        const rw = this.getProp('rot_3');
 
-        const sx = this.prop('scale_0');
-        const sy = this.prop('scale_1');
-        const sz = this.prop('scale_2');
+        const sx = this.getProp('scale_0');
+        const sy = this.getProp('scale_1');
+        const sz = this.getProp('scale_2');
 
         const splat = {
             x: 0, y: 0, z: 0, rx: 0, ry: 0, rz: 0, rw: 0, sx: 0, sy: 0, sz: 0
@@ -202,13 +202,13 @@ class SplatData {
     }
 
     calcFocalPoint(result: Vec3) {
-        const x = this.prop('x');
-        const y = this.prop('y');
-        const z = this.prop('z');
+        const x = this.getProp('x');
+        const y = this.getProp('y');
+        const z = this.getProp('z');
 
-        const sx = this.prop('scale_0');
-        const sy = this.prop('scale_1');
-        const sz = this.prop('scale_2');
+        const sx = this.getProp('scale_0');
+        const sy = this.getProp('scale_1');
+        const sz = this.getProp('scale_2');
 
         let sum = 0;
         for (let i = 0; i < this.numSplats; ++i) {

--- a/src/splat/splat-material.ts
+++ b/src/splat/splat-material.ts
@@ -117,21 +117,19 @@ const splatVS = `
 
     #endif
 
-    void computeCov3d(in vec3 rot, in vec3 scale, out vec3 covA, out vec3 covB)
+    void computeCov3d(in mat3 rot, in vec3 scale, out vec3 covA, out vec3 covB)
     {
-        mat3 R = quatToMat3(rot);
-
         // M = S * R
         float M[9] = float[9](
-            scale.x * R[0][0],
-            scale.x * R[0][1],
-            scale.x * R[0][2],
-            scale.y * R[1][0],
-            scale.y * R[1][1],
-            scale.y * R[1][2],
-            scale.z * R[2][0],
-            scale.z * R[2][1],
-            scale.z * R[2][2]
+            scale.x * rot[0][0],
+            scale.x * rot[0][1],
+            scale.x * rot[0][2],
+            scale.y * rot[1][0],
+            scale.y * rot[1][1],
+            scale.y * rot[1][2],
+            scale.z * rot[2][0],
+            scale.z * rot[2][1],
+            scale.z * rot[2][2]
         );
 
         covA = vec3(
@@ -165,7 +163,7 @@ const splatVS = `
         vec3 splat_covb;
         vec3 scale = getScale();
         vec3 rotation = getRotation();
-        computeCov3d(rotation, scale, splat_cova, splat_covb);
+        computeCov3d(mat3(matrix_model) * quatToMat3(rotation), scale, splat_cova, splat_covb);
 
         mat3 Vrk = mat3(
             splat_cova.x, splat_cova.y, splat_cova.z, 

--- a/src/splat/splat-resource.ts
+++ b/src/splat/splat-resource.ts
@@ -51,7 +51,7 @@ class SplatResource extends ContainerResource {
 
     instantiateRenderEntity(options: any): Entity {
         const splat = new Splat(this.device);
-        splat.create(this.splatData, options);
+        splat.create(this.splatData);
 
         const result = new Entity('ply');
         result.addComponent('render', {
@@ -83,7 +83,7 @@ class SplatResource extends ContainerResource {
 
         // initialize sort
         this.sortManager = new SortManager();
-        const sortJob = this.sortManager.sort(
+        this.sortManager.sort(
             splat.meshInstance.instancingData.vertexBuffer,
             centers,
             this.device.isWebGPU,

--- a/src/splat/splat-resource.ts
+++ b/src/splat/splat-resource.ts
@@ -70,9 +70,9 @@ class SplatResource extends ContainerResource {
         this.splatData.calcFocalPoint(this.focalPoint);
 
         // centers - constant buffer that is sent to the worker
-        const x = this.splatData.prop('x');
-        const y = this.splatData.prop('y');
-        const z = this.splatData.prop('z');
+        const x = this.splatData.getProp('x');
+        const y = this.splatData.getProp('y');
+        const z = this.splatData.getProp('z');
 
         const centers = new Float32Array(this.splatData.numSplats * 3);
         for (let i = 0; i < this.splatData.numSplats; ++i) {

--- a/src/splat/splat-resource.ts
+++ b/src/splat/splat-resource.ts
@@ -1,7 +1,9 @@
 import {
+    BoundingBox,
     ContainerResource,
     Entity,
     GraphicsDevice,
+    Mat4,
     Material,
     Mesh,
     RenderComponent,
@@ -11,10 +13,18 @@ import {
 
 import { SplatData } from './splat-data';
 import { Splat } from './splat';
+import { SortManager } from './sort-manager';
+
+const mat = new Mat4();
+const pos = new Vec3();
+const dir = new Vec3();
+
+const debugRenderBounds = false;
 
 class SplatResource extends ContainerResource {
     device: GraphicsDevice;
     splatData: SplatData;
+    sortManager: SortManager;
 
     focalPoint = new Vec3();
     entity: Entity;
@@ -40,7 +50,6 @@ class SplatResource extends ContainerResource {
     }
 
     instantiateRenderEntity(options: any): Entity {
-
         const splat = new Splat(this.device);
         splat.create(this.splatData, options);
 
@@ -51,12 +60,59 @@ class SplatResource extends ContainerResource {
             castShadows: false                  // shadows not supported
         });
 
-        // set custom aabb
-        result.render.customAabb = splat.aabb;
-
-        this.focalPoint.copy(splat.focalPoint);
-
         this.entity = result;
+
+        // set custom aabb
+        const customAabb = new BoundingBox();
+        this.splatData.calcAabb(customAabb);
+        result.render.customAabb = customAabb;
+
+        this.splatData.calcFocalPoint(this.focalPoint);
+
+        // centers - constant buffer that is sent to the worker
+        const x = this.splatData.prop('x');
+        const y = this.splatData.prop('y');
+        const z = this.splatData.prop('z');
+
+        const centers = new Float32Array(this.splatData.numSplats * 3);
+        for (let i = 0; i < this.splatData.numSplats; ++i) {
+            centers[i * 3 + 0] = x[i];
+            centers[i * 3 + 1] = y[i];
+            centers[i * 3 + 2] = z[i];
+        }
+
+        // initialize sort
+        this.sortManager = new SortManager();
+        const sortJob = this.sortManager.sort(
+            splat.meshInstance.instancingData.vertexBuffer,
+            centers,
+            this.device.isWebGPU,
+            options?.onChanged
+        );
+
+        const viewport = [0, 0];
+
+        options.app.on('prerender', () => {
+            const cameraMat = options.camera.getWorldTransform();
+            cameraMat.getTranslation(pos);
+            cameraMat.getZ(dir);
+
+            const modelMat = this.entity.getWorldTransform();
+            const invModelMat = mat.invert(modelMat);
+            invModelMat.transformPoint(pos, pos);
+            invModelMat.transformVector(dir, dir);
+
+            this.sortManager.setCamera(pos, dir);
+
+            viewport[0] = this.device.width;
+            viewport[1] = this.device.height;
+            splat.meshInstance.material.setParameter('viewport', viewport);
+
+            // debug render splat bounds
+            if (debugRenderBounds) {
+                this.splatData.renderWireframeBounds(options.app, modelMat);
+            }
+        });
 
         return result;
     }

--- a/src/splat/splat.ts
+++ b/src/splat/splat.ts
@@ -154,10 +154,10 @@ class Splat {
 
         const SH_C0 = 0.28209479177387814;
 
-        const f_dc_0 = splatData.prop('f_dc_0');
-        const f_dc_1 = splatData.prop('f_dc_1');
-        const f_dc_2 = splatData.prop('f_dc_2');
-        const opacity = splatData.prop('opacity');
+        const f_dc_0 = splatData.getProp('f_dc_0');
+        const f_dc_1 = splatData.getProp('f_dc_1');
+        const f_dc_2 = splatData.getProp('f_dc_2');
+        const opacity = splatData.getProp('opacity');
 
         const texture = this.createTexture('splatColor', PIXELFORMAT_RGBA8, size);
         const data = texture.lock();
@@ -193,9 +193,9 @@ class Splat {
         // texture format based vars
         const { numComponents, isHalf } = format;
 
-        const scale0 = splatData.prop('scale_0');
-        const scale1 = splatData.prop('scale_1');
-        const scale2 = splatData.prop('scale_2');
+        const scale0 = splatData.getProp('scale_0');
+        const scale1 = splatData.getProp('scale_1');
+        const scale2 = splatData.getProp('scale_2');
 
         const texture = this.createTexture('splatScale', format.format, size);
         const data = texture.lock();
@@ -227,10 +227,10 @@ class Splat {
         const { numComponents, isHalf } = format;
         const quat = new Quat();
 
-        const rot0 = splatData.prop('rot_0');
-        const rot1 = splatData.prop('rot_1');
-        const rot2 = splatData.prop('rot_2');
-        const rot3 = splatData.prop('rot_3');
+        const rot0 = splatData.getProp('rot_0');
+        const rot1 = splatData.getProp('rot_1');
+        const rot2 = splatData.getProp('rot_2');
+        const rot3 = splatData.getProp('rot_3');
 
         const texture = this.createTexture('splatRotation', format.format, size);
         const data = texture.lock();
@@ -263,9 +263,9 @@ class Splat {
         // texture format based vars
         const { numComponents, isHalf } = format;
 
-        const x = splatData.prop('x');
-        const y = splatData.prop('y');
-        const z = splatData.prop('z');
+        const x = splatData.getProp('x');
+        const y = splatData.getProp('y');
+        const z = splatData.getProp('z');
 
         const texture = this.createTexture('splatCenter', format.format, size);
         const data = texture.lock();
@@ -288,9 +288,9 @@ class Splat {
     }
 
     create(splatData: SplatData) {
-        const x = splatData.prop('x');
-        const y = splatData.prop('y');
-        const z = splatData.prop('z');
+        const x = splatData.getProp('x');
+        const y = splatData.getProp('y');
+        const z = splatData.getProp('z');
 
         if (!x || !y || !z) {
             return;

--- a/src/splat/splat.ts
+++ b/src/splat/splat.ts
@@ -27,7 +27,6 @@ import { createSplatMaterial } from "./splat-material";
 
 // set true to render splats as oriented boxes
 const debugRender = false;
-const debugRenderBounds = false;
 
 const floatView = new Float32Array(1);
 const int32View = new Int32Array(floatView.buffer);
@@ -288,7 +287,7 @@ class Splat {
         return texture;
     }
 
-    create(splatData: SplatData, options: any) {
+    create(splatData: SplatData) {
         const x = splatData.prop('x');
         const y = splatData.prop('y');
         const z = splatData.prop('z');


### PR DESCRIPTION
This PR address a few issues with splat sorting:
- render splats orientation correctly with non-identity model matrix
- sort splats correctly with non-identity model matrix

Also:
- added function to transform `SplatData`, used to orientate the scene at load time
- split out worker code with view to supporting multiple splats in future