### PR TITLE
Splat sort update

### DIFF
--- a/src/splat/sort-manager.ts
+++ b/src/splat/sort-manager.ts
@@ -16,8 +16,8 @@ function SortWorker() {
     let cameraDirection: Vec3;
     let intIndices: boolean;
 
-    let boundMin = { x: 0, y: 0, z: 0 };
-    let boundMax = { x: 0, y: 0, z: 0 };
+    const boundMin = { x: 0, y: 0, z: 0 };
+    const boundMax = { x: 0, y: 0, z: 0 };
 
     const lastCameraPosition = { x: 0, y: 0, z: 0 };
     const lastCameraDirection = { x: 0, y: 0, z: 0 };
@@ -62,7 +62,7 @@ function SortWorker() {
             target = new Float32Array(numVertices);
         }
 
-        // calc min/max
+        // calc min/max distance using bound
         let minDist;
         let maxDist
         for (let i = 0; i < 8; ++i) {

--- a/src/splat/sort-manager.ts
+++ b/src/splat/sort-manager.ts
@@ -64,7 +64,7 @@ function SortWorker() {
 
         // calc min/max distance using bound
         let minDist;
-        let maxDist
+        let maxDist;
         for (let i = 0; i < 8; ++i) {
             const x = i & 1 ? boundMin.x : boundMax.x;
             const y = i & 2 ? boundMin.y : boundMax.y;


### PR DESCRIPTION
Before sorting splats in the worker we must calculate the splat distance min and max so we can pack the normalised distances into an integer array for sorting.

Instead of running through all splats each time to calculate min and max, we use the splat bounding box instead, saving on sort time.