### PR TITLE
Splat and camera updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "model-viewer",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "model-viewer",
-      "version": "4.6.0",
+      "version": "4.7.0",
       "license": "MIT",
       "devDependencies": {
         "@playcanvas/eslint-config": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-viewer",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "author": "PlayCanvas<support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "PlayCanvas glTF Viewer",

--- a/src/splat/splat.ts
+++ b/src/splat/splat.ts
@@ -157,12 +157,26 @@ class Splat {
             { semantic: SEMANTIC_ATTR13, components: 1, type: device.isWebGPU ? TYPE_UINT32 : TYPE_FLOAT32 }
         ]);
 
+        // initialize index data
+        let indexData;
+        if (device.isWebGPU) {
+            indexData = new Uint32Array(numSplats);
+            for (let i = 0; i < numSplats; ++i) {
+                indexData[i] = i;
+            }
+        } else {
+            indexData = new Float32Array(numSplats);
+            for (let i = 0; i < numSplats; ++i) {
+                indexData[i] = i + 0.2;
+            }
+        }
+
         const vertexBuffer = new VertexBuffer(
             device,
             vertexFormat,
             numSplats,
             BUFFER_DYNAMIC,
-            new ArrayBuffer(numSplats * 4)
+            indexData.buffer
         );
 
         this.meshInstance = new MeshInstance(this.mesh, this.material);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -914,12 +914,11 @@ class Viewer {
             this.initialCameraPosition = null;
         } else {
             // automatically placed camera position
-            const radius = bbox.halfExtents.length();
-            const distance = (radius * 1.4) / Math.sin(0.5 * camera.fov * camera.aspectRatio * math.DEG_TO_RAD);
             aed.copy(this.orbitCamera.azimElevDistance.target);
-            aed.z = distance;
+            aed.z = 1.4 / Math.sin(0.5 * camera.fov * camera.aspectRatio * math.DEG_TO_RAD);
         }
 
+        this.orbitCamera.sceneSize = bbox.halfExtents.length();
         this.orbitCamera.azimElevDistance[func](aed);
         this.orbitCamera.focalPoint[func](focus);
     }
@@ -1560,14 +1559,20 @@ class Viewer {
         // dirty everything
         this.dirtyWireframe = this.dirtyBounds = this.dirtySkeleton = this.dirtyGrid = this.dirtyNormals = true;
 
-        // reset scene offset
-        this.sceneRoot.setLocalPosition(0, 0, 0);
+        // calculate scene bounds after first render in order to get accurate morph target and skinned bounds
+        this.calcSceneBounds(this.sceneBounds);
 
-        // we can't refocus the camera here because the scene hierarchy only gets updated
-        // during render. we must instead set a flag, wait for a render to take place and
-        // then focus the camera.
-        this.firstFrame = true;
+        // offset scene geometry to place it at the origin
+        this.sceneRoot.setLocalPosition(-this.sceneBounds.center.x, -this.sceneBounds.getMin().y, -this.sceneBounds.center.z);
+
+        // set projective skybox radius
+        this.projectiveSkybox.domeRadius = this.sceneBounds.halfExtents.length() * this.observer.get('skybox.domeProjection.domeRadius');
+
+        this.focusCamera();
         this.renderNextFrame();
+
+        // we perform some special processing on the first frame
+        this.firstFrame = true;
     }
 
     // rebuild the animation state graph
@@ -1668,6 +1673,7 @@ class Viewer {
     // generate and render debug elements on prerender
     private onPrerender() {
         if (this.firstFrame) {
+            this.firstFrame = false;
             return;
         }
 
@@ -1797,7 +1803,7 @@ class Viewer {
     private onPostrender() {
         // resolve the (possibly multisampled) render target
         const rt = this.camera.camera.renderTarget;
-        if (!this.app.graphicsDevice.isWebGPU && !this.firstFrame && rt._samples > 1) {
+        if (!this.app.graphicsDevice.isWebGPU /*&& !this.firstFrame*/ && rt._samples > 1) {
             rt.resolve();
         }
 
@@ -1810,18 +1816,6 @@ class Viewer {
         if (this.firstFrame) {
             this.firstFrame = false;
 
-            // calculate scene bounds after first render in order to get accurate morph target and skinned bounds
-            this.calcSceneBounds(this.sceneBounds);
-
-            // offset scene geometry to place it at the origin
-            this.sceneRoot.setLocalPosition(-this.sceneBounds.center.x, -this.sceneBounds.getMin().y, -this.sceneBounds.center.z);
-            // this.sceneRoot.setLocalEulerAngles(-90, -90, 0);
-
-            // set projective skybox radius
-            this.projectiveSkybox.domeRadius = this.sceneBounds.halfExtents.length() * this.observer.get('skybox.domeProjection.domeRadius');
-
-            this.focusCamera();
-            this.renderNextFrame();
         }
 
         if (this.loadTimestamp !== null) {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1803,7 +1803,7 @@ class Viewer {
     private onPostrender() {
         // resolve the (possibly multisampled) render target
         const rt = this.camera.camera.renderTarget;
-        if (!this.app.graphicsDevice.isWebGPU /*&& !this.firstFrame*/ && rt._samples > 1) {
+        if (!this.app.graphicsDevice.isWebGPU && rt._samples > 1) {
             rt.resolve();
         }
 
@@ -1813,11 +1813,6 @@ class Viewer {
     }
 
     private onFrameend() {
-        if (this.firstFrame) {
-            this.firstFrame = false;
-
-        }
-
         if (this.loadTimestamp !== null) {
             this.observer.set('scene.loadTime', `${Date.now() - this.loadTimestamp}ms`);
             this.loadTimestamp = null;


### PR DESCRIPTION
This PR updates the viewer as follows:
- initialise splat order buffer so first frame is sensible
- clamp orbit camera min/max
- calculate scene bounds in first frame