### PR TITLE
Fix camera focus of skinned meshes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "model-viewer",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "model-viewer",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "devDependencies": {
         "@playcanvas/eslint-config": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-viewer",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "author": "PlayCanvas<support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "PlayCanvas glTF Viewer",

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1559,6 +1559,16 @@ class Viewer {
         // dirty everything
         this.dirtyWireframe = this.dirtyBounds = this.dirtySkeleton = this.dirtyGrid = this.dirtyNormals = true;
 
+        this.initSceneBounds();
+        this.renderNextFrame();
+
+        // we perform some special processing on the first frame
+        this.firstFrame = true;
+    }
+
+    private initSceneBounds() {
+        this.sceneRoot.setLocalPosition(0, 0, 0);
+
         // calculate scene bounds after first render in order to get accurate morph target and skinned bounds
         this.calcSceneBounds(this.sceneBounds);
 
@@ -1568,11 +1578,8 @@ class Viewer {
         // set projective skybox radius
         this.projectiveSkybox.domeRadius = this.sceneBounds.halfExtents.length() * this.observer.get('skybox.domeProjection.domeRadius');
 
+        // set camera clipping planes
         this.focusCamera();
-        this.renderNextFrame();
-
-        // we perform some special processing on the first frame
-        this.firstFrame = true;
     }
 
     // rebuild the animation state graph
@@ -1673,7 +1680,6 @@ class Viewer {
     // generate and render debug elements on prerender
     private onPrerender() {
         if (this.firstFrame) {
-            this.firstFrame = false;
             return;
         }
 
@@ -1801,6 +1807,13 @@ class Viewer {
     }
 
     private onPostrender() {
+        if (this.firstFrame) {
+            this.firstFrame = false;
+
+            // reinit scene bounds after first render in order to get accurate morph target and skinned bounds
+            this.initSceneBounds();
+        }
+
         // resolve the (possibly multisampled) render target
         const rt = this.camera.camera.renderTarget;
         if (!this.app.graphicsDevice.isWebGPU && rt._samples > 1) {


### PR DESCRIPTION
This PR fixes https://forum.playcanvas.com/t/model-viewer-4-7-0/33617.

The scene bound is only valid after rendering the scene once when skinned meshes are loaded.

In this PR we re-calculate the scene bounds and focus the camera again after the first render.