### PR TITLE
Set import paths correctly for PCUI React

### DIFF
--- a/src/ui/components/index.tsx
+++ b/src/ui/components/index.tsx
@@ -8,7 +8,7 @@ import {
     SliderInput,
     VectorInput,
     NumericInput
-} from 'pcui';
+} from '@playcanvas/pcui/react';
 import { Option } from '../../types';
 
 export const Detail = (props: { label: string, value:string|number}) => {

--- a/src/ui/errors.tsx
+++ b/src/ui/errors.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InfoBox } from 'pcui';
+import { InfoBox } from '@playcanvas/pcui/react';
 import { ObserverData } from '../types';
 
 // InfoBox that shows an error

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,7 +1,7 @@
 import { Observer } from '@playcanvas/observer';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Container, Spinner } from 'pcui';
+import { Container, Spinner } from '@playcanvas/pcui/react';
 
 import { getAssetPath } from '../helpers';
 import { ObserverData } from '../types';

--- a/src/ui/left-panel/index.tsx
+++ b/src/ui/left-panel/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Panel, Container, TreeViewItem, TreeView } from 'pcui';
+import { Panel, Container, TreeViewItem, TreeView } from '@playcanvas/pcui/react';
 import { HierarchyNode, SetProperty, ObserverData } from '../../types';
 
 import { Detail, Select, Toggle, Vector } from '../components';

--- a/src/ui/left-panel/morph-target-panel.tsx
+++ b/src/ui/left-panel/morph-target-panel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import { MorphTargetData, SetProperty, ObserverData } from '../../types';
-import { Panel } from 'pcui';
+import { Panel } from '@playcanvas/pcui/react';
 import { MorphSlider } from '../components';
 
 class MorphTargetPanel extends React.Component <{ morphs: ObserverData['morphs'], progress: number, setProperty: SetProperty }> {

--- a/src/ui/load-controls.tsx
+++ b/src/ui/load-controls.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Container, Label, Button, TextInput } from 'pcui';
+import { Container, Label, Button, TextInput } from '@playcanvas/pcui/react';
 import { getAssetPath } from '../helpers';
 
 import { File, SetProperty } from '../types';

--- a/src/ui/popup-panel/animation-controls.tsx
+++ b/src/ui/popup-panel/animation-controls.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'pcui';
+import { Button } from '@playcanvas/pcui/react';
 import { SetProperty, ObserverData } from '../../types';
 
 import { NakedSelect, NakedSlider } from '../components';

--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Observer } from '@playcanvas/observer';
-import { Button } from 'pcui';
+import { Button } from '@playcanvas/pcui/react';
 import { SetProperty, ObserverData } from '../../types';
 import AnimationControls from './animation-controls';
 import { CameraPanel, SkyboxPanel, LightPanel, DebugPanel, ViewPanel } from './panels';

--- a/src/ui/popup-panel/panels.tsx
+++ b/src/ui/popup-panel/panels.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Button, Label, TextInput } from 'pcui';
+import { Container, Button, Label, TextInput } from '@playcanvas/pcui/react';
 import { SetProperty, ObserverData } from '../../types';
 import { extract } from '../../helpers';
 // @ts-ignore no type defs included

--- a/src/ui/selected-node.tsx
+++ b/src/ui/selected-node.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container } from 'pcui';
+import { Container } from '@playcanvas/pcui/react';
 import { SetProperty, ObserverData } from '../types';
 
 import { Vector, Detail } from './components';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
         "noEmit": true,
         "baseUrl": ".",
         "paths": {
-            "pcui": ["node_modules/@playcanvas/pcui"],
             "playcanvas-extras": ["node_modules/playcanvas/build/playcanvas-extras.mjs"]
         }
     },


### PR DESCRIPTION
This PR updates the Model Viewer React code to import PCUI in the way recommended by the [PCUI docs](https://playcanvas.github.io/pcui/react/), namely:

```
import { TextInput } from '@playcanvas/pcui/react';
```

This eliminates a large number of Intellisense errors in the project across all the `.tsx` files. For example, errors like these:

![image](https://github.com/playcanvas/model-viewer/assets/697563/a8118834-acea-471b-aec4-e13adeca48ad)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
