### PR TITLE
Fix path to PCUI in tsconfig.json

### DIFF
--- a/src/ui/popup-panel/index.tsx
+++ b/src/ui/popup-panel/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Observer } from '@playcanvas/observer';
 import { Button } from 'pcui';
 import { SetProperty, ObserverData } from '../../types';
 import AnimationControls from './animation-controls';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         "noEmit": true,
         "baseUrl": ".",
         "paths": {
-            "pcui": ["node_modules/@playcanvas/pcui"],
+            "pcui": ["node_modules/@playcanvas/pcui/react"],
             "playcanvas-extras": ["node_modules/playcanvas/build/playcanvas-extras.mjs"]
         }
     },


### PR DESCRIPTION
Fix Intellisense errors related to PCUI React components. Also remove an unused import.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
