### PR TITLE
Use PCUI for scrollbar styling

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -740,20 +740,6 @@ input {
     top: calc(50% - 15px);
 }
 
-::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-}
-::-webkit-scrollbar-track {
-    background: #202020;
-}
-::-webkit-scrollbar-thumb {
-    background: #aaaaaa;
-}
-/* ::-webkit-scrollbar-corner {
-    background: $editor-tooltip-bg;
-} */
-
 #panel-left.collapsed #scene-container, #panel-left.collapsed .header {
     display: none !important;
 }


### PR DESCRIPTION
Scrollbar styling was implemented in PCUI in 4.4.0: https://github.com/playcanvas/pcui/releases/tag/v4.4.0

This means that Model Viewer no longer needs to specify its own scrollbar styling so it is removed in this PR.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
